### PR TITLE
Hyper small updates to script and package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "psu_deploy": "python3 ./safe_setup.py",
-    "win_deploy": "python ./safe_setup.py"
+    "debug_deploy": "python3 ./safe_setup.py -d || (cls || clear & python ./safe_setup.py -d)"
   },
   "eslintConfig": {
     "extends": [

--- a/safe_setup.py
+++ b/safe_setup.py
@@ -324,11 +324,11 @@ def main():
     # this message will appear and the script will terminate with sys.exit
     if whoIsMyHost() is False and not __DEBUG:
         print(
-            "This script can only be ran on Portland State University "
-            + "linux servers owned and operated by the CAT.\n"
-            + "If this message is printed in error, the script needs to "
-            + "be updated. Contact the development team for more "
-            + "support.\n"
+            "\nThis script can only be ran on Portland State University "
+            "linux servers owned and operated by the CAT."
+            "\nIf this message is printed in error, the script needs to "
+            "be updated. Contact the development team for more "
+            "support.\n"
         )
         sys.exit()
 
@@ -336,7 +336,7 @@ def main():
     if __DEBUG:
         print(
             "\n\nDEBUG MODE DETECTED. . .    SCRIPT WILL CONTINUE IN 3 "
-            + "SECONDS. . .\n\n"
+            "SECONDS. . .\n\n"
         )
         time.sleep(2)
 


### PR DESCRIPTION
These changes are meant to be fully inclusive of expected operational usage for multiple kinds of operators of the script. `npm run debug_deploy` will execute one of two versions of python depending on the system being used. 

Unix type systems use `python3` where  as Windows uses `python` - `npm run debug_deploy` supports this semantic difference in command line operations.